### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout-v21/new_password.xml
+++ b/app/src/main/res/layout-v21/new_password.xml
@@ -11,6 +11,7 @@
         android:layout_alignParentStart="true"
         android:hint="@string/hint_field_new_password"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="24dp"
         android:layout_marginStart="24dp"
@@ -23,6 +24,7 @@
         android:layout_below="@id/field_password"
         android:hint="@string/hint_field_conf_password"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:layout_marginEnd="24dp"
         android:layout_marginStart="24dp"
         android:maxLines="1"/>

--- a/app/src/main/res/layout/insert_password.xml
+++ b/app/src/main/res/layout/insert_password.xml
@@ -12,5 +12,6 @@
         android:layout_marginTop="16dp"
         android:hint="@string/hint_field_password"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:maxLines="1"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/new_password.xml
+++ b/app/src/main/res/layout/new_password.xml
@@ -11,6 +11,7 @@
         android:layout_alignParentLeft="true"
         android:hint="@string/hint_field_new_password"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:maxLines="1" />
 
     <EditText
@@ -20,6 +21,7 @@
         android:layout_below="@id/field_password"
         android:hint="@string/hint_field_conf_password"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:maxLines="1" />
 
 </RelativeLayout>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.